### PR TITLE
Disable tinyusb with cmake

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -1,0 +1,39 @@
+# This starter workflow is for a CMake project running on a single platform. There is a different starter workflow if you need cross-platform coverage.
+# See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-multi-platform.yml
+name: CMake on a single platform
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -C ${{env.BUILD_TYPE}}
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,13 +19,32 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Set the path to our custom SDK config header before anything else
+set(PICO_SDK_CONFIG_HEADER_PATH ${CMAKE_CURRENT_LIST_DIR}/pico_sdk_config.h)
+
 set(PICO_BOARD pico CACHE STRING "Board type") # NOTE: Use "pico" or "pico_w"
 
-# Disable TinyUSB support
+# Disable TinyUSB support more thoroughly
 set(PICO_DISABLE_TINYUSB ON)
+set(PICO_SDK_TINYUSB_PATH "" CACHE INTERNAL "")
+set(ENABLE_USB 0)
+set(PICO_STDIO_USB 0)
+add_compile_definitions(CFG_TUSB_OS=OPT_OS_NONE)
+add_compile_definitions(USB_MAX_ENDPOINTS=0)
+
+# Create empty functions to override TinyUSB inclusion
+function(pico_add_tinyusb_no_op)
+endfunction()
 
 # Pull in Raspberry Pi Pico SDK (must be before project)
 include(pico_sdk_import.cmake)
+
+# Override SDK functions that might try to include TinyUSB
+if(COMMAND pico_add_subdirectory_tinyusb)
+    function(pico_add_subdirectory_tinyusb)
+        # Do nothing to prevent TinyUSB from being included
+    endfunction()
+endif()
 
 project(piccolo C CXX ASM)
 
@@ -50,7 +69,7 @@ target_sources(piccolo PUBLIC
 
 # Modify the below lines to enable/disable output over UART/USB
 pico_enable_stdio_uart(piccolo 1)
-pico_enable_stdio_usb(piccolo 0)
+pico_enable_stdio_usb(piccolo 0)  # Ensure USB stdio is disabled
 
 # Add the standard library to the build
 target_link_libraries(piccolo
@@ -67,9 +86,9 @@ target_include_directories(piccolo PRIVATE
 # Add any user requested libraries
 target_link_libraries(piccolo
   # pico_cyw43_arch_none # NOTE: Enable this for "pico_w"
-	pico_stdlib
-	hardware_resets
-	hardware_irq
+    pico_stdlib
+    hardware_resets
+    hardware_irq
 )
 
 pico_add_extra_outputs(piccolo)

--- a/README.md
+++ b/README.md
@@ -37,14 +37,7 @@ directory contains some configuration for this setup.
 
 ## Disable TinyUSB
 
-Since this repo doesn't use TinyUSB at all, we need to disable it from the
-pico-sdk code. The only way I found to do this is by commenting out the
-following lines in `${PICO_SDK_PATH}/src/rp2_common/CMakeLists.txt`.
-
-```
-# pico_add_subdirectory(tinyusb)
-# pico_add_subdirectory(pico_stdio_usb)
-```
+Since this repo doesn't use TinyUSB at all, it's been disabled through the CMake configs
 
 ## RP2040 Notes
 

--- a/pico_sdk_config.h
+++ b/pico_sdk_config.h
@@ -1,0 +1,22 @@
+#ifndef PICO_SDK_CONFIG_H
+#define PICO_SDK_CONFIG_H
+
+// This file contains overrides for Pico SDK configuration
+
+// Explicitly disable TinyUSB
+#define PICO_ENABLE_USB 0
+#define PICO_USB_DEVICE_ENABLE 0
+#define PICO_USB_HOST_ENABLE 0
+#define PICO_STDIO_USB_ENABLE 0
+#define PICO_STDIO_USB_DEFAULT_CRLF 0
+
+// Disable TinyUSB device stack
+#define CFG_TUD_ENABLED 0
+
+// Disable TinyUSB host stack
+#define CFG_TUH_ENABLED 0
+
+// Ensure stdio USB is not enabled
+#define PICO_STDIO_USB 0
+
+#endif // PICO_SDK_CONFIG_H


### PR DESCRIPTION
This should disable tinyusb without needing to edit files outside of the project